### PR TITLE
Fix packCWString and friends

### DIFF
--- a/lib/Data/ByteString/Short.hs
+++ b/lib/Data/ByteString/Short.hs
@@ -147,26 +147,9 @@ import Prelude hiding
     , takeWhile
     )
 
-import Data.ByteString.Short.Internal
-import "bytestring" Data.ByteString.Short
-    ( ShortByteString
-    , empty
-    , fromShort
-    , index
-#if MIN_VERSION_bytestring(0,11,0)
-    , indexMaybe
-    , (!?)
-#endif
-    , length
-    , null
-    , pack
-    , toShort
-    , unpack
-    )
 import "bytestring" Data.ByteString.Short.Internal
-    ( createFromPtr )
+import Data.ByteString.Short.Internal
 import Data.Word8
-
 
 import qualified "bytestring" Data.ByteString.Short as BS
 import qualified "bytestring" Data.ByteString.Short.Internal as BS

--- a/shortbytestring.cabal
+++ b/shortbytestring.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               shortbytestring
-version:            0.1.0.0
+version:            0.2.0.0
 license:            MIT
 license-file:       LICENSE
 maintainer:         hasufell@posteo.de
@@ -33,6 +33,7 @@ library
 
   hs-source-dirs:           lib
   default-language:         Haskell2010
+  ghc-options: -Wall -Wextra
   build-depends:
     , base              >=4.9.1.0  && <5
     , bytestring        ^>=0.10.8.1
@@ -84,6 +85,7 @@ test-suite prop-compiled
     , tasty-quickcheck
     , word16
     , word8
+    , QuickCheck
 
   ghc-options:      -fwarn-unused-binds -threaded -rtsopts
   default-language: Haskell2010

--- a/tests/Properties/ByteString/Common.hs
+++ b/tests/Properties/ByteString/Common.hs
@@ -20,11 +20,11 @@
 
 #ifdef WORD8
 module Properties.ByteString.Short (tests) where
-import Data.Word8 (isSpace)
+import Data.Word8 (isSpace, _nul)
 import qualified "shortbytestring" Data.ByteString.Short as B
 #else
 module Properties.ByteString.Short.Word16 (tests) where
-import Data.Word16 (isSpace)
+import Data.Word16 (isSpace, _nul)
 import qualified "shortbytestring" Data.ByteString.Short.Word16 as B
 #endif
 import "shortbytestring" Data.ByteString.Short (ShortByteString)
@@ -38,6 +38,7 @@ import Data.Semigroup
 import Data.Tuple
 import Test.Tasty
 import Test.Tasty.QuickCheck
+import Test.QuickCheck.Monadic
 import Text.Show.Functions ()
 
 #ifdef WORD16
@@ -396,6 +397,22 @@ tests =
   --, testProperty "unfoldr" $
   --  \n f (toElem -> a) -> B.unpack (B.take (fromIntegral n) (B.unfoldr (fmap (first toElem) . f) a)) ===
   --    take n (unfoldr (fmap (first toElem) . f) a)
+  --
+#ifdef WORD16
+  , testProperty "useAsCWString str packCWString == str" $
+    \x -> not (B.any (== _nul) x)
+      ==> monadicIO $ run (B.useAsCWString x B.packCWString >>= \x' -> pure (x === x'))
+  , testProperty "useAsCWStringLen str packCWStringLen == str" $
+    \x -> not (B.any (== _nul) x)
+      ==> monadicIO $ run (B.useAsCWStringLen x B.packCWStringLen >>= \x' -> pure (x === x'))
+#else
+  , testProperty "useAsCString str packCString == str" $
+    \x -> not (B.any (== _nul) x)
+      ==> monadicIO $ run (B.useAsCString x B.packCString >>= \x' -> pure (x === x'))
+  , testProperty "useAsCStringLen str packCStringLen == str" $
+    \x -> not (B.any (== _nul) x)
+      ==> monadicIO $ run (B.useAsCStringLen x B.packCStringLen >>= \x' -> pure (x === x'))
+#endif
   ]
 
 stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]


### PR DESCRIPTION
CWchar is platform dependent. We want the same behavior
across all platforms though. The most reliable way hence
is to replace CWchar with 'Ptr Word16' and let the Win32
API run `fromInteger`.