### PR TITLE
Fix memory safety issues

### DIFF
--- a/lib/Data/ByteString/Short.hs
+++ b/lib/Data/ByteString/Short.hs
@@ -201,7 +201,7 @@ snoc :: ShortByteString -> Word8 -> ShortByteString
 snoc = \sbs c -> let l = BS.length sbs
                      nl = l + 1
   in create nl $ \mba -> do
-      copyByteArray (asBA sbs) 0 mba 0 nl
+      copyByteArray (asBA sbs) 0 mba 0 l
       writeWord8Array mba l c
 {-# INLINE snoc #-}
 
@@ -209,8 +209,9 @@ snoc = \sbs c -> let l = BS.length sbs
 --
 -- Note: copies the entire byte array
 cons :: Word8 -> ShortByteString -> ShortByteString
-cons c = \sbs -> let l = BS.length sbs + 1
-  in create l $ \mba -> do
+cons c = \sbs -> let l = BS.length sbs
+                     nl = l + 1
+  in create nl $ \mba -> do
       writeWord8Array mba 0 c
       copyByteArray (asBA sbs) 0 mba 1 l
 {-# INLINE cons #-}

--- a/lib/Data/ByteString/Short/Internal.hs
+++ b/lib/Data/ByteString/Short/Internal.hs
@@ -268,8 +268,9 @@ indexWord16Array (BA# ba#) (I# i#) =
   case (# indexWord8Array# ba# i#, indexWord8Array# ba# (i# +# 1#) #) of
     (# lsb#, msb# #) -> W16# ((decodeWord16LE# (# lsb#, msb# #)))
 
+#if !MIN_VERSION_base(4,16,0)
 
-encodeWord16LE# :: Word# -- ^ Word16
+encodeWord16LE# :: Word#              -- ^ Word16
                 -> (# Word#, Word# #) -- ^ Word8 (LSB, MSB)
 encodeWord16LE# x# = (# (x# `and#` int2Word# 0xff#)
                      ,  ((x# `and#` int2Word# 0xff00#) `shiftRL#` 8#) #)
@@ -278,4 +279,19 @@ decodeWord16LE# :: (# Word#, Word# #) -- ^ Word8 (LSB, MSB)
                 -> Word#              -- ^ Word16
 decodeWord16LE# (# lsb#, msb# #) = ((msb# `shiftL#` 8#) `or#` lsb#)
 
+#else
 
+encodeWord16LE# :: Word16#              -- ^ Word16
+                -> (# Word8#, Word8# #) -- ^ Word8 (LSB, MSB)
+encodeWord16LE# x# = (# word16ToWord8# x#
+                     ,  word16ToWord8# (x# `uncheckedShiftRLWord16#` 8#) #)
+  where
+    word16ToWord8# y = wordToWord8# (word16ToWord# y)
+
+decodeWord16LE# :: (# Word8#, Word8# #) -- ^ Word8 (LSB, MSB)
+                -> Word16#              -- ^ Word16
+decodeWord16LE# (# lsb#, msb# #) = ((word8ToWord16# msb# `uncheckedShiftLWord16#` 8#) `orWord16#` word8ToWord16# lsb#)
+  where
+    word8ToWord16# y = wordToWord16# (word8ToWord# y)
+
+#endif

--- a/lib/Data/ByteString/Short/Word16.hs
+++ b/lib/Data/ByteString/Short/Word16.hs
@@ -221,7 +221,7 @@ snoc :: ShortByteString -> Word16 -> ShortByteString
 snoc = \(assertEven -> sbs) c -> let l = BS.length sbs
                                      nl = l + 2
   in create nl $ \mba -> do
-      copyByteArray (asBA sbs) 0 mba 0 nl
+      copyByteArray (asBA sbs) 0 mba 0 l
       writeWord16Array mba l c
 {-# INLINE snoc #-}
 
@@ -233,7 +233,7 @@ cons c = \(assertEven -> sbs) -> let l = BS.length sbs
                                      nl = l + 2
   in create nl $ \mba -> do
       writeWord16Array mba 0 c
-      copyByteArray (asBA sbs) 0 mba 2 nl
+      copyByteArray (asBA sbs) 0 mba 2 l
 {-# INLINE cons #-}
 
 -- | /O(1)/ Extract the last element of a ShortByteString, which must be finite and at least one Word16.


### PR DESCRIPTION
Previously `cons` and `snoc` would overflow its destination buffer. Appears to fix #4.

Also, add compatibility for `text-2.0` and GHC 9.2.