### PR TITLE
Add big-endian CI build

### DIFF
--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -1,0 +1,46 @@
+# Emulation is incredibly slow and memory demanding. It seems that any
+# executable with GHC RTS takes at least 7-8 Gb of RAM, so we can run
+# `cabal` or `ghc` on their own, but cannot run them both at the same time,
+# striking out `cabal test`. Instead we rely on system packages and invoke
+# `ghc --make` manually, and even so `ghc -O` is prohibitively expensive.
+
+name: s390x
+on:
+  - push
+  - pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  emulated:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: ['s390x']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: uraimo/run-on-arch-action@v2.1.1
+      timeout-minutes: 60
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        install: |
+          apt-get update -y
+          apt-get install -y ghc libghc-tasty-quickcheck-dev curl
+        run: |
+          ghc --version
+          curl -s -L https://hackage.haskell.org/package/word16-0.1.0.0.tar.gz | tar xz
+          curl -s -L https://hackage.haskell.org/package/word8-0.1.3.tar.gz | tar xz
+          sed -i 's/module Data.ByteString.Short/module Data.ByteString.Short_/g' lib/Data/ByteString/{Short.hs,Short/*}
+          sed -i 's/"shortbytestring" Data.ByteString.Short/Data.ByteString.Short_/g' lib/Data/ByteString/{Short.hs,Short/*} tests/Properties/ByteString/Common.hs
+          sed -i 's/import Data.ByteString.Short/import Data.ByteString.Short_/g' lib/Data/ByteString/Short/Word16.hs
+          sed -i 's/import Data.ByteString.Short.Internal/import Data.ByteString.Short_.Internal/g' lib/Data/ByteString/Short.hs
+          mv lib/Data/ByteString/Short.hs lib/Data/ByteString/Short_.hs
+          mv lib/Data/ByteString/Short lib/Data/ByteString/Short_
+          sed -i 's/Data.ByteString.Short /Data.ByteString.Short_ /g' tests/Properties/ByteString/Common.hs
+          ghc --make -ilib:tests:word8-0.1.3:word16-0.1.0.0/lib -o Main tests/Properties.hs
+          ./Main


### PR DESCRIPTION
I was curious to validate statements about LE / BE stuff in `Word16` modules and put up an s390x build. It's very rough indeed, so I'm fine with this being rejected, just wanted to share that it is green :)